### PR TITLE
Fix PM startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ huge values.  This seems to be a start-up timing issue, as reinstalling the code
 I think the PM sensor just needs time to warm up before the ESP32 trys to use it, and the ESPHome code is not waiting long enough before giving up on it.
 
 To do: 
+- <strike>Fix startup issue with PM sensor</strike>
 - Document required hardware BOM
 - Tweak sampling rates to increase life of PM sensor
 - Add a gas sensor for CO, Ozone, VOC, etc.

--- a/wesp-1.yaml
+++ b/wesp-1.yaml
@@ -53,6 +53,7 @@ sensor:
 
     # Particulate
   - platform: pmsa003i
+    setup_priority: -100 # delay startup since otherwise it will not work on cold start!
     pm_1_0:
       name: ${prefixname} PM1.0
     pm_2_5:
@@ -183,8 +184,17 @@ text_sensor:
     id: ${prefixname}_uptime_human
     icon: mdi:clock-start
 
-
-
+# Remote reboot, shutdown, and safe mode switches
+switch:
+  - platform: restart
+    name: Restart
+    id: ${prefixname}_restart
+  - platform: safe_mode
+    name: Restart (Safe Mode)
+    id: ${prefixname}_restart_safe
+  - platform: shutdown
+    name: Shutdown
+    id: ${prefixname}_shutdown
 
 # UI for manual calibration of CO2 sensor.  Enter calibration value
 # first, then press button.  Sensor should be in a stable environment 


### PR DESCRIPTION
- lower priority of PM sensor startup so it has time to initialize after a cold start.  Otherwise it hangs (although it does come online otherwise with a "warm start" e.g. an install or remote reboot.  Problem is probably large startup power requirements due to the fan spinning up).
- add remote reboot and shutdown controls